### PR TITLE
(Proposal) updated @mixin list-inline()

### DIFF
--- a/scss/baseguide/01-tools/_mixins.scss
+++ b/scss/baseguide/01-tools/_mixins.scss
@@ -82,13 +82,12 @@
 
   display: flex;
   flex-wrap: wrap;
-  margin-left: $spacing * -1;
 
   @if $center {
     justify-content: center;
   }
 
-  > #{$child-selector} {
+  > #{$child-selector} & #{$child-selector} {
     margin-left: $spacing;
   }
 }


### PR DESCRIPTION
Hi,

Please see https://codepen.io/KasperAndersson/pen/GaZqKr, to understand the proposal.

TL;DR: Negative `margin-left`, under parent selector will make siblings "not-clickable"..