### PR TITLE
Adds `$font-size-base` as default

### DIFF
--- a/scss/baseguide/01-tools/_functions.scss
+++ b/scss/baseguide/01-tools/_functions.scss
@@ -17,7 +17,7 @@
   @return $return;
 }
 
-@function modular-scale($exp, $size, $type-scale: $type-scale) {
+@function modular-scale($exp, $size: $font-size-base, $type-scale: $type-scale) {
   @return pow($type-scale, $exp) * $size;
 }
 


### PR DESCRIPTION
Adds `$font-size-base` as default value for `$size` in `modular-scale`-function.